### PR TITLE
Fix runner version

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Now you're ready to go!
 | `github-runner-install-dir` | `start` |          | Directory to install the runner in (default: `/opt/actions-runner`)                                                                             |
 | `github-runner-timeout`     | `start` |          | Minutes to wait for runners to register themselves (default: 5)                                                                                 |
 | `github-runner-user`        | `start` |          | User to run workflows as (default: `root`)                                                                                                      |
-| `github-runner-version`     | `start` |          | Version of the GitHub runner to install (default: `2.283.1`)                                                                                    |
+| `github-runner-version`     | `start` |          | Version of the GitHub runner to install (default: `2.303.0`)                                                                                    |
 | `aws-ec2-instance-ids`      | `stop`  | yes      | EC2 Instance IDs of runners created in a prior `start` step.                                                                                    |
 | `github-runner-label`       | `stop`  | yes      | Unique label assigned to the runners in the `start` step.                                                                                       |
 

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ inputs:
     description: >-
       Version of the GitHub runner to install.
     required: false
-    default: '2.283.1'
+    default: '2.303.0'
 
   # mode=stop
   aws-ec2-instance-ids:


### PR DESCRIPTION
Change default runner to `2.303.0`
`index.js` was unchanged from running `npm run package`